### PR TITLE
Setting the collect_ipaddress variable

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,7 @@ class icinga::params {
   $nrpe_allowed_hosts          = [ '127.0.0.1,', $::ipaddress ]
   $nrpe_server_address         = $::ipaddress
   $icinga_admins               = '*'
+  $collect_ipaddress           = $::ipaddress
   $collect_hostname            = $::fqdn
   $notification_cmd_host       = 'notify-host-by-email'
   $notification_cmd_service    = 'notify-service-by-email'


### PR DESCRIPTION
The ::icinga::params::collect_ipaddress variable is used for setting up hosts, but isn't actually set any where. I've set it in params to default to ::ipaddress.
