### PR TITLE
Timeperiods and hostgroups shouldn't be exported

### DIFF
--- a/manifests/collect.pp
+++ b/manifests/collect.pp
@@ -14,18 +14,10 @@ class icinga::collect {
     Nagios_contactgroup <<| |>>      { notify => Service[$::icinga::service_server] }
     Nagios_hostdependency <<| |>>    { notify => Service[$::icinga::service_server] }
     Nagios_hostescalation <<| |>>    { notify => Service[$::icinga::service_server] }
-    Nagios_hostgroup <<| |>>         {
-      notify => Service[$::icinga::service_server],
-      target => "${::icinga::targetdir}/hostgroups.cfg",
-    }
     Nagios_servicedependency <<| |>> { notify => Service[$::icinga::service_server] }
     Nagios_serviceescalation <<| |>> { notify => Service[$::icinga::service_server] }
     Nagios_serviceextinfo <<| |>>    { notify => Service[$::icinga::service_server] }
     Nagios_servicegroup <<| |>>      { notify => Service[$::icinga::service_server] }
-    Nagios_timeperiod <<| |>>        {
-      notify => Service[$::icinga::service_server],
-      target => "${::icinga::targetdir}/timeperiods.cfg",
-    }
     Icinga::Downtime <<| |>>         { notify => Service[$::icinga::service_server] }
   }
 

--- a/manifests/default/hostgroups.pp
+++ b/manifests/default/hostgroups.pp
@@ -1,12 +1,17 @@
 class icinga::default::hostgroups {
 
-  @@nagios_hostgroup{'all':
+  Nagios_hostgroup {
+    notify => Service[$::icinga::service_server],
+    target => "${::icinga::targetdir}/hostgroups.cfg",
+  }
+
+  nagios_hostgroup{'all':
     hostgroup_name => 'all',
     alias          => 'All Servers',
     members        => '*',
   }
 
-  @@nagios_hostgroup{'default':
+  nagios_hostgroup{'default':
     hostgroup_name => 'default',
     alias          => 'Default hostgroup',
   }

--- a/manifests/default/timeperiods.pp
+++ b/manifests/default/timeperiods.pp
@@ -1,6 +1,11 @@
 class icinga::default::timeperiods {
 
-  @@nagios_timeperiod{'24x7':
+  Nagios_timeperiod {
+    notify => Service[$::icinga::service_server],
+    target => "${::icinga::targetdir}/timeperiods.cfg",
+  }
+
+  nagios_timeperiod{'24x7':
     timeperiod_name => '24x7',
     alias           => 'Purgatory',
     monday          => '00:00-24:00',
@@ -12,7 +17,7 @@ class icinga::default::timeperiods {
     sunday          => '00:00-24:00',
   }
 
-  @@nagios_timeperiod{'workhours':
+  nagios_timeperiod{'workhours':
     timeperiod_name => 'workhours',
     alias           => 'Daily Routine',
     monday          => '09:00-18:00',
@@ -22,7 +27,7 @@ class icinga::default::timeperiods {
     friday          => '09:00-18:00',
   }
 
-  @@nagios_timeperiod{'nonworkhours':
+  nagios_timeperiod{'nonworkhours':
     timeperiod_name => 'nonworkhours',
     alias           => 'On Call Doody',
     monday          => '00:00-09:00,18:00-24:00',
@@ -34,7 +39,7 @@ class icinga::default::timeperiods {
     sunday          => '00:00-24:00',
   }
 
-  @@nagios_timeperiod{'never':
+  nagios_timeperiod{'never':
     timeperiod_name => 'never',
     alias           => 'Ignorance Is Bliss',
   }


### PR DESCRIPTION
Timeperiods and hostgroups shouldn't be exported. That can cause duplicates in the puppet catalog when using more than one Icinga server.
