### PR TITLE
checkpercona-replication-delay: explicitly check if $serverid is undef o...

### DIFF
--- a/manifests/plugins/checkpercona-replication-delay.pp
+++ b/manifests/plugins/checkpercona-replication-delay.pp
@@ -16,7 +16,7 @@ class icinga::plugins::checkpercona-replication-delay (
 
 ) inherits icinga {
 
-  if ($serverid == undef) {
+  if ! $serverid {
     fail('You should provide an serverid but did not set the var')
   }
 


### PR DESCRIPTION
Explicitly check if $serverid is undef otherwise valid variables will still fail

Signed-off-by: Christophe Vanlancker christophe.vanlancker@inuits.eu
