### PR TITLE
Enable gzip compression for webui if mod_deflate is available

### DIFF
--- a/templates/redhat/httpd.conf.erb
+++ b/templates/redhat/httpd.conf.erb
@@ -39,3 +39,10 @@ Alias /icinga "/usr/share/icinga/"
   Require valid-user
 <% end %>
 </Directory>
+
+<ifmodule mod_deflate.c>
+  AddOutputFilterByType DEFLATE text/text text/html text/plain text/xml text/css text/json application/x-javascript application/javascript
+  BrowserMatch ^Mozilla/4 gzip-only-text/html
+  BrowserMatch ^Mozilla/4\.0[678] no-gzip
+  BrowserMatch \bMSIE !no-gzip !gzip-only-text/html
+</ifmodule>

--- a/templates/redhat/httpd_debian.conf.erb
+++ b/templates/redhat/httpd_debian.conf.erb
@@ -23,3 +23,10 @@ Alias /icinga /usr/share/icinga/htdocs
   AuthUserFile /etc/icinga/htpasswd.users
   require valid-user
 </DirectoryMatch>
+
+<ifmodule mod_deflate.c>
+  AddOutputFilterByType DEFLATE text/text text/html text/plain text/xml text/css text/json application/x-javascript application/javascript
+  BrowserMatch ^Mozilla/4 gzip-only-text/html
+  BrowserMatch ^Mozilla/4\.0[678] no-gzip
+  BrowserMatch \bMSIE !no-gzip !gzip-only-text/html
+</ifmodule>


### PR DESCRIPTION
This is specially handy for external apps like aNag which pulls down the status via JSON output (recommended) over slow/unreliable networks.

Signed-off-by: Christophe Vanlancker christophe.vanlancker@inuits.eu
