### PR TITLE
set_expire_ack_by_default should be in cgi.cnf

### DIFF
--- a/templates/debian/cgi.cfg
+++ b/templates/debian/cgi.cfg
@@ -383,3 +383,14 @@ lock_author_names=1
 # This option should be the URL used to access your instance of Splunk
 
 #splunk_url=http://127.0.0.1:8000/
+
+
+
+
+# SET EXPIRE ACK BY DEFAULT
+# This option either sets or clears the checkbox for "Use Expire Time"
+# in the acknowledgement menu.  Valid values are 0 (DO NOT tick the
+# checkbox by default) or 1 (tick the checkbox by default).  The default
+# is 0 (leave the checkbox blank).
+
+set_expire_ack_by_default=<%= scope.lookupvar('icinga::set_expire_ack_by_default') -%>

--- a/templates/debian/icinga.cfg
+++ b/templates/debian/icinga.cfg
@@ -367,16 +367,6 @@ log_passive_checks=1
 
 
 
-# SET EXPIRE ACK BY DEFAULT
-# This option either sets or clears the checkbox for "Use Expire Time"
-# in the acknowledgement menu.  Valid values are 0 (DO NOT tick the
-# checkbox by default) or 1 (tick the checkbox by default).  The default
-# is 0 (leave the checkbox blank).
-
-set_expire_ack_by_default=<%= scope.lookupvar('icinga::set_expire_ack_by_default') -%>
-
-
-
 # GLOBAL HOST AND SERVICE EVENT HANDLERS
 # These options allow you to specify a host and service event handler
 # command that is to be run for every host or service state change.

--- a/templates/redhat/cgi.cfg.erb
+++ b/templates/redhat/cgi.cfg.erb
@@ -433,3 +433,14 @@ lock_author_names=1
 # This option should be the URL used to access your instance of Splunk
 
 #splunk_url=http://127.0.0.1:8000/
+
+
+
+
+# SET EXPIRE ACK BY DEFAULT
+# This option either sets or clears the checkbox for "Use Expire Time"
+# in the acknowledgement menu.  Valid values are 0 (DO NOT tick the
+# checkbox by default) or 1 (tick the checkbox by default).  The default
+# is 0 (leave the checkbox blank).
+
+set_expire_ack_by_default=<%= scope.lookupvar('icinga::set_expire_ack_by_default') -%>

--- a/templates/redhat/icinga.cfg.erb
+++ b/templates/redhat/icinga.cfg.erb
@@ -369,16 +369,6 @@ log_passive_checks=1
 
 
 
-# SET EXPIRE ACK BY DEFAULT
-# This option either sets or clears the checkbox for "Use Expire Time"
-# in the acknowledgement menu.  Valid values are 0 (DO NOT tick the
-# checkbox by default) or 1 (tick the checkbox by default).  The default
-# is 0 (leave the checkbox blank).
-
-set_expire_ack_by_default=<%= scope.lookupvar('icinga::set_expire_ack_by_default') -%>
-
-
-
 # GLOBAL HOST AND SERVICE EVENT HANDLERS
 # These options allow you to specify a host and service event handler
 # command that is to be run for every host or service state change.


### PR DESCRIPTION
Made an eror in my previous pull request, this one works on our infra so should be ok to use!

Signed-off-by: Patrick Van Brussel patrick@inuits.eu
