### PR TITLE
nrpe: add check_ping command as default

### DIFF
--- a/templates/common/nrpe.cfg.erb
+++ b/templates/common/nrpe.cfg.erb
@@ -189,3 +189,4 @@ command[check_disk]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/chec
 command[check_zombie_procs]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_procs -w 5 -c 10 -s Z
 command[check_total_procs]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_procs -w 250 -c 350
 command[check_mem]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_mem -w 90,25 -c 95,50
+command[check_ping]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_ping -H $ARG1$ -4 -w $ARG2$ -c $ARG3$ -p 5


### PR DESCRIPTION
Mighty handy to be able to check connectivity from the perspective of a remote host to somewhere else.

Signed-off-by: Christophe Vanlancker christophe.vanlancker@inuits.eu
