### PR TITLE
Configurable check proc

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -166,10 +166,11 @@ class icinga::params {
 
     default: {}
   }
-  # Plugin Defaults
-  $checktotalprocs_warning_level  = 700
-  $checktotalprocs_critical_level = 2000
-}
+
+  # Plugin defaults
+  $checktotalprocs_warning_level  = 250
+  $checktotalprocs_critical_level = 350
+
   # Needs to be down here since $usrlib is defined in the distro specific params
   $plugindir                 = "${usrlib}/nagios/plugins"
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -166,7 +166,10 @@ class icinga::params {
 
     default: {}
   }
-
+  # Plugin Defaults
+  $checktotalprocs_warning_level  = 700
+  $checktotalprocs_critical_level = 2000
+}
   # Needs to be down here since $usrlib is defined in the distro specific params
   $plugindir                 = "${usrlib}/nagios/plugins"
 

--- a/manifests/plugins/checktotalprocs.pp
+++ b/manifests/plugins/checktotalprocs.pp
@@ -9,13 +9,13 @@ class icinga::plugins::checktotalprocs (
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,
-  $warning_level         = $::icinga::params::checktotalprocs_warning_level,
-  $critical_level        = $::icinga::params::checktotalprocs_critical_level,
+  $check_warning         = $::icinga::params::checktotalprocs_warning_level,
+  $check_critical        = $::icinga::params::checktotalprocs_critical_level,
 ) inherits icinga {
 
   if $icinga::client {
     @@nagios_service { "check_total_procs_${::fqdn}":
-      check_command         => "check_nrpe_command_args!check_total_procs!${icinga::plugins::checktotalprocs::warning_level} ${icinga::plugins::checktotalprocs::critical_level}",
+      check_command         => "check_nrpe_command_args!check_total_procs!${check_warning} ${check_critical}",
       service_description   => 'Total processes',
       contact_groups        => $contact_groups,
       host_name             => $::fqdn,

--- a/manifests/plugins/checktotalprocs.pp
+++ b/manifests/plugins/checktotalprocs.pp
@@ -9,11 +9,13 @@ class icinga::plugins::checktotalprocs (
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,
+  $warning_level         = $::icinga::params::checktotalprocs_warning_level,
+  $critical_level        = $::icinga::params::checktotalprocs_critical_level,
 ) inherits icinga {
 
   if $icinga::client {
     @@nagios_service { "check_total_procs_${::fqdn}":
-      check_command         => 'check_nrpe_command!check_total_procs',
+      check_command         => "check_nrpe_command_args!check_total_procs!${icinga::plugins::checktotalprocs::warning_level} ${icinga::plugins::checktotalprocs::critical_level}",
       service_description   => 'Total processes',
       contact_groups        => $contact_groups,
       host_name             => $::fqdn,

--- a/templates/common/nrpe.cfg.erb
+++ b/templates/common/nrpe.cfg.erb
@@ -187,6 +187,6 @@ include_dir=<%= scope.lookupvar('icinga::includedir_client') %>
 command[check_users]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_users -w 5 -c 10
 command[check_disk]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_disk -w 20% -c 10%
 command[check_zombie_procs]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_procs -w 5 -c 10 -s Z
-command[check_total_procs]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_procs -w 250 -c 350
+command[check_total_procs]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_procs -w $ARG1$ -c $ARG2$
 command[check_mem]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_mem -w 90,25 -c 95,50
 command[check_ping]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_ping -H $ARG1$ -4 -w $ARG2$ -c $ARG3$ -p 5

--- a/templates/common/nrpe.cfg.erb
+++ b/templates/common/nrpe.cfg.erb
@@ -187,7 +187,7 @@ include_dir=<%= scope.lookupvar('icinga::includedir_client') %>
 command[check_users]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_users -w 5 -c 10
 command[check_disk]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_disk -w 20% -c 10%
 command[check_zombie_procs]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_procs -w 5 -c 10 -s Z
-<% if nrpe_allow_arguments==1 -%>
+<% if scope.lookupvar('icinga::nrpe_allow_arguments') == '1' -%>
 command[check_total_procs]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_procs -w $ARG1$ -c $ARG2$
 <% else -%>
 command[check_total_procs]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_procs -w <%= scope.lookupvar('icinga::params::checktotalprocs_warning_level') %> -c <%= scope.lookupvar('icinga::params::checktotalprocs_critical_level') %>

--- a/templates/common/nrpe.cfg.erb
+++ b/templates/common/nrpe.cfg.erb
@@ -187,6 +187,10 @@ include_dir=<%= scope.lookupvar('icinga::includedir_client') %>
 command[check_users]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_users -w 5 -c 10
 command[check_disk]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_disk -w 20% -c 10%
 command[check_zombie_procs]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_procs -w 5 -c 10 -s Z
+<% if nrpe_allow_arguments==1 -%>
 command[check_total_procs]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_procs -w $ARG1$ -c $ARG2$
+<% else -%>
+command[check_total_procs]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_procs -w <%= scope.lookupvar('icinga::params::checktotalprocs_warning_level') %> -c <%= scope.lookupvar('icinga::params::checktotalprocs_critical_level') %>
+<% end -%>
 command[check_mem]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_mem -w 90,25 -c 95,50
 command[check_ping]=<%= scope.lookupvar('icinga::usrlib') %>/nagios/plugins/check_ping -H $ARG1$ -4 -w $ARG2$ -c $ARG3$ -p 5


### PR DESCRIPTION
To make it work with more environments we made the check_total_procs NRPE check have configurable warning and critical levels. It does mean that it needs NRPE allow args to be turned on now though.