### PR TITLE
Avoid sending notifications to root@localhost

### DIFF
--- a/templates/debian/objects/contacts_icinga.cfg
+++ b/templates/debian/objects/contacts_icinga.cfg
@@ -19,8 +19,8 @@ define contact{
         alias                           Root
         service_notification_period     24x7
         host_notification_period        24x7
-        service_notification_options    w,u,c,r
-        host_notification_options       d,r
+        service_notification_options    n
+        host_notification_options       n
         service_notification_commands   notify-service-by-email
         host_notification_commands      notify-host-by-email
         email                           root@localhost

--- a/templates/redhat/notifications.cfg.erb
+++ b/templates/redhat/notifications.cfg.erb
@@ -19,8 +19,8 @@ define contact{
         alias                           Root
         service_notification_period     24x7
         host_notification_period        24x7
-        service_notification_options    w,u,c,r
-        host_notification_options       d,r
+        service_notification_options    n
+        host_notification_options       n
         service_notification_commands   notify-service-by-email
         host_notification_commands      notify-host-by-email
         email                           root@localhost


### PR DESCRIPTION
Icinga has a default user root with hardcoded root@localhost email address.

Each time there are notifications/alerts, a mail is being sent. A mail server obviously doesn't know how to handle root@localhost so it piles up in the deferred queue.
