### PR TITLE
make contact_groups configurable for all plugins from the base class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -128,6 +128,7 @@ class icinga (
   $process_service_perfdata_file             = $::icinga::params::process_service_perfdata_file,
   $service_perfdata_file_template            = $::icinga::params::service_perfdata_file_template,
   $service_perfdata_file_processing_interval = $::icinga::params::service_perfdata_file_processing_interval,
+  $contact_groups                            = $::icinga::params::contact_groups,
 ) inherits icinga::params {
 
   # motd::register { 'icinga-refactor': }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,6 +40,7 @@ class icinga::params {
   $process_service_perfdata_file             = 'process-service-perfdata-file'
   $service_perfdata_file_template            = 'DATATYPE::SERVICEPERFDATA\tTIMET::$TIMET$\tHOSTNAME::$HOSTNAME$\tSERVICEDESC::$SERVICEDESC$\tSERVICEPERFDATA::$SERVICEPERFDATA$\tSERVICECHECKCOMMAND::$SERVICECHECKCOMMAND$\tHOSTSTATE::$HOSTSTATE$\tHOSTSTATETYPE::$HOSTSTATETYPE$\tSERVICESTATE::$SERVICESTATE$\tSERVICESTATETYPE::$SERVICESTATETYPE'
   $service_perfdata_file_processing_interval = '15'
+  $contact_groups                            = $::environment
 
   case $::operatingsystem {
     'Debian', 'Ubuntu': {

--- a/manifests/plugins/checkalldisks.pp
+++ b/manifests/plugins/checkalldisks.pp
@@ -6,7 +6,7 @@ class icinga::plugins::checkalldisks (
   $check_warning         = '10%',
   $check_critical        = '5%',
   $max_check_attempts    = $::icinga::max_check_attempts,
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,
 ) inherits icinga {

--- a/manifests/plugins/checkbacula.pp
+++ b/manifests/plugins/checkbacula.pp
@@ -7,7 +7,7 @@ define icinga::plugins::checkbacula (
   $jobname               = $::fqdn,
   $warning               = '1',
   $critical              = '0',
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,
 ) {

--- a/manifests/plugins/checkcrm.pp
+++ b/manifests/plugins/checkcrm.pp
@@ -10,7 +10,7 @@ class icinga::plugins::checkcrm (
   $notification_period    = $::icinga::notification_period,
   $notifications_enabled  = $::icinga::notifications_enabled,
   $host_name              = $::fqdn,
-  $contact_groups         = $::environment,
+  $contact_groups         = $::icinga::contact_groups,
 ) {
 
   require icinga

--- a/manifests/plugins/checkcron.pp
+++ b/manifests/plugins/checkcron.pp
@@ -3,7 +3,7 @@
 # This class provides a checkcron plugin.
 #
 class icinga::plugins::checkcron (
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkdns.pp
+++ b/manifests/plugins/checkdns.pp
@@ -5,7 +5,7 @@
 define icinga::plugins::checkdns (
   $expected_answer,
   $dnsname               = $name,
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $notification_period   = $::icinga::notification_period,
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notifications_enabled = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkdrbd.pp
+++ b/manifests/plugins/checkdrbd.pp
@@ -10,7 +10,7 @@ class icinga::plugins::checkdrbd (
   $notification_period    = $::icinga::notification_period,
   $notifications_enabled  = $::icinga::notifications_enabled,
   $host_name              = $::fqdn,
-  $contact_groups         = $::environment,
+  $contact_groups         = $::icinga::contact_groups,
 ) {
 
   require icinga

--- a/manifests/plugins/checkdrupal.pp
+++ b/manifests/plugins/checkdrupal.pp
@@ -3,7 +3,7 @@
 # This class provides a checkdrupal plugin.
 #
 class icinga::plugins::checkdrupal (
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkdrupalcron.pp
+++ b/manifests/plugins/checkdrupalcron.pp
@@ -11,7 +11,7 @@ define icinga::plugins::checkdrupalcron (
   $notification_period    = $::icinga::notification_period,
   $notifications_enabled  = $::icinga::notifications_enabled,
   $host_name              = $::fqdn,
-  $contact_groups         = $::environment,
+  $contact_groups         = $::icinga::contact_groups,
   $warning                = '3600',
   $critical               = '7200',
   $uri                    = '',

--- a/manifests/plugins/checkhttpd.pp
+++ b/manifests/plugins/checkhttpd.pp
@@ -6,7 +6,7 @@ class icinga::plugins::checkhttpd (
   $ensure                = present,
   $perfdata              = false,
   $perfargs              = '',
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkicingareload.pp
+++ b/manifests/plugins/checkicingareload.pp
@@ -7,7 +7,7 @@ class icinga::plugins::checkicingareload (
     'centos' => 'nagios-plugins-icinga-reload-check',
     'debian' => 'nagios-plugin-icinga-reload-check',
   },
-  $contact_groups                           = $::environment,
+  $contact_groups                           = $::icinga::contact_groups,
   $max_check_attempts                       = $::icinga::params::max_check_attempts,
   $notification_period                      = $::icinga::notification_period,
   $notifications_enabled                    = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkiostatdisk.pp
+++ b/manifests/plugins/checkiostatdisk.pp
@@ -4,7 +4,7 @@
 #
 class icinga::plugins::checkiostatdisk (
   $disk                  = $name,
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkipsec.pp
+++ b/manifests/plugins/checkipsec.pp
@@ -5,7 +5,7 @@
 class icinga::plugins::checkipsec (
   $pkgname               = 'nagios-plugins-ipsec',
   $tunnels               = '1',
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,

--- a/manifests/plugins/checklengthydrupalcron.pp
+++ b/manifests/plugins/checklengthydrupalcron.pp
@@ -13,7 +13,7 @@ define icinga::plugins::checklengthydrupalcron (
   $notification_period    = $::icinga::notification_period,
   $notifications_enabled  = $::icinga::notifications_enabled,
   $host_name              = $::fqdn,
-  $contact_groups         = $::environment,
+  $contact_groups         = $::icinga::contact_groups,
   $warning                = '1800',
   $critical               = '3600',
 ) {

--- a/manifests/plugins/checkload.pp
+++ b/manifests/plugins/checkload.pp
@@ -6,7 +6,7 @@ class icinga::plugins::checkload (
   $pkgname               = 'nagios-plugins-load',
   $check_warning         = hiera('nagios_load_warning', '15,10,5'),
   $check_critical        = hiera('nagios_load_critical', '30,25,20'),
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkmailman.pp
+++ b/manifests/plugins/checkmailman.pp
@@ -11,7 +11,7 @@ define icinga::plugins::checkmailman (
   $notification_period    = $::icinga::notification_period,
   $notifications_enabled  = $::icinga::notifications_enabled,
   $host_name              = $::fqdn,
-  $contact_groups         = $::environment,
+  $contact_groups         = $::icinga::contact_groups,
   $warning                = '15',
   $critical               = '30',
   $dir                    = '/var/spool/mailman',

--- a/manifests/plugins/checkmailq.pp
+++ b/manifests/plugins/checkmailq.pp
@@ -7,7 +7,7 @@ class icinga::plugins::checkmailq (
   $check_warning         = '5',
   $check_critical        = '10',
   $mailserver_type       = 'postfix',
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkmegaraid.pp
+++ b/manifests/plugins/checkmegaraid.pp
@@ -9,7 +9,7 @@ class icinga::plugins::checkmegaraid (
   $predictive_errors_ignore_count = '0',
   $other_disk_errors_ignore_count = '0',
   $max_check_attempts             = $::icinga::max_check_attempts,
-  $contact_groups                 = $::environment,
+  $contact_groups                 = $::icinga::contact_groups,
   $notification_period            = $::icinga::notification_period,
   $notifications_enabled          = $::icinga::notifications_enabled,
 ) inherits icinga {

--- a/manifests/plugins/checkmem.pp
+++ b/manifests/plugins/checkmem.pp
@@ -3,7 +3,7 @@
 # This class provides a checkmem plugin.
 #
 class icinga::plugins::checkmem (
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkmongodb.pp
+++ b/manifests/plugins/checkmongodb.pp
@@ -4,7 +4,7 @@
 #
 class icinga::plugins::checkmongodb (
   $ensure                       = present,
-  $contact_groups               = $::environment,
+  $contact_groups               = $::icinga::contact_groups,
   $max_check_attempts           = $::icinga::max_check_attempts,
   $notification_period          = $::icinga::notification_period,
   $notifications_enabled        = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkmount.pp
+++ b/manifests/plugins/checkmount.pp
@@ -10,7 +10,7 @@ define icinga::plugins::checkmount (
   },
   $mountpoint            = undef,
   $type                  = undef,
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $max_check_attempts    = $::icinga::params::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkmysqld.pp
+++ b/manifests/plugins/checkmysqld.pp
@@ -5,7 +5,7 @@
 class icinga::plugins::checkmysqld (
   $ensure                = present,
   $perfdata              = true,
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkntp.pp
+++ b/manifests/plugins/checkntp.pp
@@ -7,7 +7,7 @@ class icinga::plugins::checkntp (
   $warn_value            = '1',
   $crit_value            = '10',
   $timeout               = '30',
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkotrsqueue.pp
+++ b/manifests/plugins/checkotrsqueue.pp
@@ -3,7 +3,7 @@
 # This class provides a checkotrsqueue plugin.
 #
 class icinga::plugins::checkotrsqueue (
-  $contact_groups               = $::environment,
+  $contact_groups               = $::icinga::contact_groups,
   $max_check_attempts           = $::icinga::max_check_attempts,
   $notification_period          = $::icinga::notification_period,
   $notifications_enabled        = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkpercona-replication-delay.pp
+++ b/manifests/plugins/checkpercona-replication-delay.pp
@@ -10,7 +10,7 @@ class icinga::plugins::checkpercona-replication-delay (
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $warning               = '300',
   $critical              = '600',
 

--- a/manifests/plugins/checkpercona-replication.pp
+++ b/manifests/plugins/checkpercona-replication.pp
@@ -9,7 +9,7 @@ class icinga::plugins::checkpercona-replication (
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $warning               = '1',
   $critical              = '1',
   $socket                = '/var/lib/mysql/mysql.sock',

--- a/manifests/plugins/checkping.pp
+++ b/manifests/plugins/checkping.pp
@@ -5,7 +5,7 @@
 class icinga::plugins::checkping (
   $check_warning         = '',
   $check_critical        = '',
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkprocstat.pp
+++ b/manifests/plugins/checkprocstat.pp
@@ -4,7 +4,7 @@
 #
 class icinga::plugins::checkprocstat (
   $ensure                = present,
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkpuppet.pp
+++ b/manifests/plugins/checkpuppet.pp
@@ -3,7 +3,7 @@
 # This class provides a checkpuppet plugin.
 #
 class icinga::plugins::checkpuppet (
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkraid.pp
+++ b/manifests/plugins/checkraid.pp
@@ -2,7 +2,7 @@
 #
 #
 class icinga::plugins::checkraid (
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkredis.pp
+++ b/manifests/plugins/checkredis.pp
@@ -6,7 +6,7 @@ define icinga::plugins::checkredis (
   $notification_period    = $::icinga::notification_period,
   $notifications_enabled  = $::icinga::notifications_enabled,
   $host_name              = $::fqdn,
-  $contact_groups         = $::environment,
+  $contact_groups         = $::icinga::contact_groups,
   $bind_address           = 'localhost',
   $port                   = '6379',
 ) {

--- a/manifests/plugins/checkssh.pp
+++ b/manifests/plugins/checkssh.pp
@@ -6,7 +6,7 @@ class icinga::plugins::checkssh (
   $sshport               = '22',
   $check_warning         = '',
   $check_critical        = '',
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $notification_period   = $::icinga::notification_period,
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notifications_enabled = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkswap.pp
+++ b/manifests/plugins/checkswap.pp
@@ -3,7 +3,7 @@
 # This class provides a checkssh plugin.
 #
 class icinga::plugins::checkswap (
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,
 ) inherits icinga {

--- a/manifests/plugins/checktotalprocs.pp
+++ b/manifests/plugins/checktotalprocs.pp
@@ -5,7 +5,7 @@
 class icinga::plugins::checktotalprocs (
   $check_warning         = '',
   $check_critical        = '',
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $max_check_attempts    = $::icinga::max_check_attempts,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,

--- a/manifests/plugins/checkzombie.pp
+++ b/manifests/plugins/checkzombie.pp
@@ -5,7 +5,7 @@
 class icinga::plugins::checkzombie (
   $check_warning         = '',
   $check_critical        = '',
-  $contact_groups        = $::environment,
+  $contact_groups        = $::icinga::contact_groups,
   $notification_period   = $::icinga::notification_period,
   $notifications_enabled = $::icinga::notifications_enabled,
 ) inherits icinga {


### PR DESCRIPTION
Same PR as yesterday but now clean, without including files from Inuits/puppet-icinga.

Conflicts:
    manifests/plugins/checkload.pp
    manifests/plugins/checkmongodb.pp
    manifests/plugins/checkntp.pp
