### PR TITLE
Add a simple definition for a generic-contact

### DIFF
--- a/manifests/config/server/common.pp
+++ b/manifests/config/server/common.pp
@@ -88,6 +88,11 @@ class icinga::config::server::common {
     content => template('icinga/common/generic-service.cfg'),
   }
 
+  file{"${::icinga::targetdir}/generic-contact.cfg":
+    ensure  => file,
+    content => template('icinga/common/generic-contact.cfg.erb'),
+  }
+
   file{"${::icinga::sharedir_server}/images/logos":}
 
   file{"${::icinga::sharedir_server}/images/logos/os":

--- a/templates/common/generic-contact.cfg.erb
+++ b/templates/common/generic-contact.cfg.erb
@@ -1,0 +1,14 @@
+#
+# This file is managed via puppet
+#
+
+define contact{
+        name                            generic-contact     ; The name of this contact template
+        service_notification_period     24x7      ; service notifications can be sent anytime
+        host_notification_period        24x7      ; host notifications can be sent anytime
+        service_notification_options    w,u,c,r,f,s   ; send notifications for all service states, flapping events, and scheduled downtime events
+        host_notification_options       d,u,r,f,s   ; send notifications for all host states, flapping events, and scheduled downtime events
+        service_notification_commands   notify-service-by-email ; send service notifications via email
+        host_notification_commands      notify-host-by-email  ; send host notifications via email
+        register                        0           ; DONT REGISTER THIS DEFINITION - ITS NOT A REAL CONTACT, JUST A TEMPLATE!
+}


### PR DESCRIPTION
AFAICS there is no default definition for generic-contact, thus Icinga cannot start after using this module. This pull request should be seen as a starting point. The template should be extended later so that a user may define his/her own default parameters for contacts.