### PR TITLE
Added a fixture and changed parameters of exported resources

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,7 @@ fixtures:
   repositories:
     concat: 'git://github.com/ripienaar/puppet-concat.git'
     stdlib: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
+    sudo: 'https://github.com/saz/puppet-sudo'
 
   symlinks:
     icinga: "#{source_dir}"

--- a/manifests/collect.pp
+++ b/manifests/collect.pp
@@ -6,7 +6,10 @@ class icinga::collect {
 
   if $::icinga::server and $::icinga::collect_resources {
     # Set defaults for collected resources.
-    Nagios_host <<| |>>              { notify => Service[$::icinga::service_server] }
+    Nagios_host <<| |>>              { 
+                                       notify  => Service[$::icinga::service_server],
+                                       require => File["${::icinga::target_dir}/hosts"],
+                                     }
     Nagios_service <<| |>>           { notify => Service[$::icinga::service_server] }
     Nagios_hostextinfo <<| |>>       { notify => Service[$::icinga::service_server] }
     Nagios_command <<| |>>           { notify => Service[$::icinga::service_server] }
@@ -45,8 +48,8 @@ class icinga::collect {
       icon_image            => "os/${::operatingsystem}.png",
       statusmap_image       => "os/${::operatingsystem}.png",
       target                => "${::icinga::targetdir}/hosts/host-${::fqdn}.cfg",
-      owner                 => $::icinga::params::server_user,
-      group                 => $::icinga::params::server_group,
+      owner                 => $::icinga::server_user,
+      group                 => $::icinga::server_group,
     }
   }
 }

--- a/manifests/collect.pp
+++ b/manifests/collect.pp
@@ -8,7 +8,6 @@ class icinga::collect {
     # Set defaults for collected resources.
     Nagios_host <<| |>>              { 
                                        notify  => Service[$::icinga::service_server],
-                                       require => File["${::icinga::target_dir}/hosts"],
                                      }
     Nagios_service <<| |>>           { notify => Service[$::icinga::service_server] }
     Nagios_hostextinfo <<| |>>       { notify => Service[$::icinga::service_server] }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,6 +83,7 @@ class icinga (
   $nrpe_connect_timeout                      = $::icinga::params::nrpe_connect_timeout,
   $nrpe_server_address                       = $::icinga::params::nrpe_server_address,
   $nrpe_server_port                          = $::icinga::params::nrpe_server_port,
+  $nrpe_command_prefix                       = $::icinga::params::nrpe_command_prefix,
   $nrpe_allow_arguments                      = $::icinga::params::nrpe_allow_arguments,
   $nrpe_enable_debug                         = $::icinga::params::nrpe_enable_debug,
   $pidfile_client                            = $::icinga::params::pidfile_client,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -131,6 +131,11 @@ class icinga (
   $service_perfdata_file_processing_interval = $::icinga::params::service_perfdata_file_processing_interval,
 ) inherits icinga::params {
 
+  # Some safety nets
+  if $server and $::operatingsystem == 'SLES' {
+    fail("${::operatingsystem} is not supported as a server platform for the moment")
+  }
+
   # motd::register { 'icinga-refactor': }
 
   include icinga::preinstall

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -132,7 +132,7 @@ class icinga (
 ) inherits icinga::params {
 
   # Some safety nets
-  if $server and $::operatingsystem == 'SLES' {
+  if $server == true and $::operatingsystem == 'SLES' {
     fail("${::operatingsystem} is not supported as a server platform for the moment")
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -166,7 +166,53 @@ class icinga::params {
       $jasper_vhost              = '/etc/httpd/conf.d/jasperserver.conf'
     }
 
-    default: {}
+    'SLES': {
+      case $::architecture {
+        default:  { $usrlib = '/usr/lib'   }
+      }
+
+      # Icinga
+      $package_client_ensure     = 'present'
+      $package_server_ensure     = 'present'
+      $package_client            = [ 'nrpe', 'monitoring-plugins-all' ]
+      $package_server            = undef
+      $service_client            = 'nrpe'
+      $service_client_ensure     = 'running'
+      $service_client_enable     = true
+      $service_client_hasstatus  = true
+      $service_client_hasrestart = true
+      $service_client_pattern    = ''
+      $service_server            = undef
+      $service_server_ensure     = 'running'
+      $service_server_enable     = true
+      $service_server_hasstatus  = true
+      $service_server_hasrestart = true
+      $pidfile_client            = '/var/run/nagios/nrpe.pid'
+      $pidfile_server            = undef
+      $confdir_client            = '/etc/nagios'
+      $confdir_server            = undef
+      $vardir_client             = undef
+      $vardir_server             = '/var/icinga'
+      $sharedir_server           = undef
+      $includedir_client         = '/etc/nrpe.d'
+      $service_webserver         = undef
+      $webserver_user            = undef
+      $webserver_group           = undef
+      $server_user               = undef
+      $server_group              = undef
+      $client_user               = 'nagios'
+      $client_group              = 'nagios'
+      $server_cmd_group          = undef
+      $htpasswd_file             = undef
+      $targetdir                 = undef
+      $targetdir_contacts        = undef
+      $icinga_vhost              = undef
+      $mail_command              = '/bin/mail'
+    }
+
+    default: {
+      fail("${module_name}: Unsupported operatingsystem ${::operatingsystem}") 
+    }
   }
 
   # Plugin defaults

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,7 @@ class icinga::params {
   $nrpe_connect_timeout                      = '10'
   $nrpe_server_address                       = $::ipaddress
   $nrpe_server_port                          = '5666'
+  $nrpe_command_prefix                       = undef
   $nrpe_allow_arguments                      = '0'
   $nrpe_enable_debug                         = '0'
   $icinga_admins                             = '*'

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -30,7 +30,7 @@ define icinga::user (
     Exec {
       require => File[$htpasswd],
       notify  => Service[$service],
-      path    => ['/usr/bin','/bin'],
+      path    => ['/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'],
     }
 
     case $ensure {

--- a/templates/common/nrpe.cfg.erb
+++ b/templates/common/nrpe.cfg.erb
@@ -101,9 +101,11 @@ dont_blame_nrpe=<%= scope.lookupvar('icinga::nrpe_allow_arguments') %>
 # This lets the nagios user run all commands in that directory (and only them)
 # without asking for a password.  If you do this, make sure you don't give
 # random users write access to that directory or its contents!
-
+<% if scope.lookupvar('icinga::nrpe_command_prefix') -%>
+command_prefix=<%= scope.lookupvar('icinga::nrpe_command_prefix') -%>
+<% else -%>
 # command_prefix=/usr/bin/sudo
-
+<% end -%>
 
 
 # DEBUGGING OPTION


### PR DESCRIPTION
We need to use icinga::server_user because these resources will fail to apply if icinga server/client are running on different distributions. I had to change this and override the server_user/server_group attributes on the clients.