### PR TITLE
Add check_sslscan check: checks ssl grade

### DIFF
--- a/files/check_ssl
+++ b/files/check_ssl
@@ -4,9 +4,9 @@
 #
 VHOST=$1
 
-if [ ! -f "/home/icinga/${VHOST}" ]
+if [ -f "/tmp/checksslscan/${VHOST}_sslresult" ]
 then
-  STATUS=$(cat /home/icinga/${VHOST}_sslresult)
+  STATUS=$(cat /tmp/checksslscan/${VHOST}_sslresult)
   if [ "$STATUS" == 'OK - score is A' ]
   then
     echo "OK - score is A" && exit 0
@@ -14,8 +14,8 @@ then
   then
     echo "WARNING - score is B" && exit 1
   else
-    echo "Critical - score is lower then B" && exit 2
+    echo "WARNING - score is lower then B" && exit 1
   fi
 else
-  echo "Status file not found in /home/icinga" && exit 3
+  echo "Status file not found in /tmp/checksslscan" && exit 3
 fi

--- a/files/check_sslscan.pl
+++ b/files/check_sslscan.pl
@@ -1,0 +1,179 @@
+#!/usr/bin/perl 
+#
+# $Id: check_sslscan.pl 468 2015-04-13 08:09:53Z phil $
+#
+# program: check_sslscan
+# author, (c): Philippe Kueck <projects at unixadm dot org>
+#
+# requires: LWP::UserAgent, JSON, Getopt::Long, Pod::Usage
+#
+
+use strict;
+use warnings;
+
+use LWP::UserAgent;
+use JSON;
+use Getopt::Long;
+use Pod::Usage;
+
+my $api = "https://api.ssllabs.com/api/v2";
+my $score = {
+  'A+' => 7, 'A' => 6, 'A-' => 5, 'B' => 4, 'C' => 3,
+  'D' => 2, 'E' => 1, 'F' => 0, 'T' => 0, 'M' => 0
+};
+
+sub nagexit {
+  my $exitc = {0 => 'OK', 1 => 'WARNING', 2 => 'CRITICAL', 3 => 'UNKNOWN'};
+  printf "%s - %s\n", $exitc->{$_[0]}, $_[1];
+  exit $_[0]
+}
+
+my $config = {'warn' => 'B', 'crit' => 'C'};
+Getopt::Long::Configure("no_ignore_case");
+GetOptions(
+  'H=s' => \$config->{'host'},
+  'w=s' => \$config->{'warn'},
+  'c=s' => \$config->{'crit'},
+  'ip=s' => \$config->{'ip'},
+  'p' => \$config->{'publish'},
+  'x' => \$config->{'nocache'},
+  'a=i' => sub {$config->{'nocache'} = 0; $config->{'maxage'} = $_[1]},
+  'd' => \$config->{'debug'},
+  'h|help' => sub {pod2usage({'-exitval' => 3, '-verbose' => 2})}
+) or pod2usage({'-exitval' => 3, '-verbose' => 0});
+pod2usage({'-exitval' => 3, '-verbose' => 0}) unless $config->{'host'};
+
+my $ua = new LWP::UserAgent;
+$ua->agent("nagios/check_sslscan ". ('$Revision: 468 $' =~ /(\d+)/)[0]);
+
+my ($resp, $result);
+local $SIG{ALRM} = sub {nagexit 3, "timeout"};
+alarm 900;
+
+$resp = $ua->get(
+  sprintf "%s/analyze?host=%s&all=done&publish=%s&%s",
+    $api, $config->{'host'}, $config->{'publish'}?'on':'off',
+    $config->{'nocache'}?"startNew=on":
+    "fromCache=on".($config->{'maxage'}?'&maxAge='.$config->{'maxage'}:'')
+);
+
+for (;;) {
+  nagexit 3, $resp->status_line unless $resp->is_success;
+  $result = from_json($resp->decoded_content);
+  last if $result->{'status'} eq 'READY';
+  sleep 10;
+  $resp = $ua->get(
+    sprintf "%s/analyze?host=%s&all=done",
+    $api, $config->{'host'}
+  )
+}
+alarm 0;
+
+if ($config->{'ip'}) {
+  $resp = $ua->get(
+    sprintf "%s/getEndpointData?host=%s&s=%s",
+    $api, $config->{'host'}, $config->{'ip'}
+  );
+  $result = from_json($resp->decoded_content);
+  $result->{'endpoints'}[0] = $result
+}
+
+if ($config->{'debug'}) {
+  use Data::Dumper;
+  print Dumper $result
+}
+
+nagexit 3, "unknown result set" unless
+  exists $result->{'endpoints'} &&
+  exists $result->{'endpoints'}[0] &&
+  exists $result->{'endpoints'}[0]->{'grade'};
+
+my $grade = $result->{'endpoints'}[0]->{'grade'};
+
+nagexit 2, sprintf "score is %s", $grade
+  if $score->{$grade} <= $score->{$config->{'crit'}};
+nagexit 1, sprintf "score is %s", $grade
+  if $score->{$grade} <= $score->{$config->{'warn'}};
+nagexit 0, sprintf "score is %s", $grade
+
+
+__END__
+=encoding utf8
+
+=head1 NAME
+
+check_sslscan
+
+=head1 VERSION
+
+$Revision: 468 $
+
+=head1 SYNOPSIS
+
+ check_sslscan -H HOST -w GRADE -c GRADE [-p] [-x] [-a MAXAGE] [-ip IP address]
+
+=head1 OPTIONS
+
+=over 8
+
+=item B<H>
+
+Host to check using Qualys SSL Labs' sslscan.
+
+=item B<ip>
+
+IP to check when the Host has more than one endpoint
+
+=item B<w>
+
+Warn at or below grade I<GRADE> (defaults to I<B>).
+
+=item B<c>
+
+Critical at or below I<GRADE> (defaults to I<C>).
+
+=item B<p>
+
+Publish results at Qualys SSL Labs.
+
+=item B<x>
+
+do not accept cached results.
+
+=item B<a>
+
+max cache age in hours (unsets C<-x> implicitly).
+
+=item B<d>
+
+debug mode, print resulting json.
+
+=back
+
+=head1 DESCRIPTION
+
+This nagios/icinga check script checks the website's ssllabs grade.
+
+Possible grades: 'A+', 'A', 'A-', 'B'..'F', 'T' (trust issues), 'M' (certificate name mismatch).
+
+=head1 DEPENDENCIES
+
+=over 8
+
+=item C<LWP::UserAgent>
+
+=item C<JSON>
+
+=item C<Pod::Usage>
+
+=item C<Getopt::Long>
+
+=back
+
+=head1 AUTHOR
+
+Philippe Kueck <projects at unixadm dot org>
+credit for maxage goes to Alexander Prinz
+credit for endpoint ip selection to JosÃ© Miranda
+
+=cut

--- a/manifests/config/server/common.pp
+++ b/manifests/config/server/common.pp
@@ -115,6 +115,11 @@ class icinga::config::server::common {
     target       => "${::icinga::targetdir}/commands/check_nrpe_command.cfg",
   }
 
+  nagios_command{'check_nrpe_command_timeout':
+    command_line => "\$USER1\$/check_nrpe -u -t \$ARG1\$ -H \$HOSTADDRESS\$ -c \$ARG2\$",
+    target       => "${::icinga::targetdir}/commands/check_nrpe_command_timeout.cfg",
+  }
+
   nagios_service {'schedule_downtimes':
     check_command       => 'schedule_script!-d0',
     service_description => 'Schedule Downtimes',

--- a/manifests/plugins/checksslscan.pp
+++ b/manifests/plugins/checksslscan.pp
@@ -102,17 +102,25 @@ define icinga::plugins::checksslscan (
       }
     }
 
+    if (!defined(File['/tmp/checksslscan'])) {
+      file { '/tmp/checksslscan':
+        ensure => directory,
+        owner  => $::icinga::client_user,
+        group  => $::icinga::clinet_group,
+      }
+    }
+
     file{"${::icinga::includedir_client}/check_sslscan_${host_url}.cfg":
       ensure  => 'file',
       mode    => '0644',
       owner   => $::icinga::client_user,
       group   => $::icinga::client_group,
-      content => "command[check_sslscan_${host_url}]=${::icinga::plugindir}/check_ssl\n",
+      content => "command[check_sslscan_${host_url}]=${::icinga::plugindir}/check_ssl ${host_url}\n",
       notify  => Service[$::icinga::service_client],
     }
 
     cron { "check-ssl-${host_url}":
-      command  => "${::icinga::plugindir}/check_sslscan.pl -H ${host_url} -w ${warning_grade} -c ${critical_grade} ${_publish_results}${_accept_cached_results}${_max_cache_age}${_ip_address}${_debug_mode}\n",
+      command  => "${::icinga::plugindir}/check_sslscan.pl -H ${host_url} -w ${warning_grade} -c ${critical_grade} ${_publish_results}${_accept_cached_results}${_max_cache_age}${_ip_address}${_debug_mode} > /tmp/checksslscan/${host_url}_sslresult\n",
       user     => $::icinga::client_user,
       month    => '*',
       monthday => '*',

--- a/manifests/plugins/checksslscan.pp
+++ b/manifests/plugins/checksslscan.pp
@@ -112,7 +112,7 @@ define icinga::plugins::checksslscan (
     }
 
     cron { "check-ssl-${host_url}":
-      command  => "${::icinga::plugindir}/check_sslscan.pl -H ${host_url} -w ${warning_grade} -c ${critical_grade} ${_publish_results}${_accept_cached_results}${_max_cache_a    ge}${_ip_address}${_debug_mode}\n",
+      command  => "${::icinga::plugindir}/check_sslscan.pl -H ${host_url} -w ${warning_grade} -c ${critical_grade} ${_publish_results}${_accept_cached_results}${_max_cache_age}${_ip_address}${_debug_mode}\n",
       user     => $::icinga::client_user,
       month    => '*',
       monthday => '*',

--- a/manifests/plugins/checksslscan.pp
+++ b/manifests/plugins/checksslscan.pp
@@ -100,8 +100,8 @@ define icinga::plugins::checksslscan (
     }
 
     @@nagios_service { "check_sslscan_${::fqdn}_${host_url}":
-      check_command         => "check_nrpe_command_timeout!180!check_sslscan_${host_url}",
-      check_interval        => '3600', # Every hour is fine
+      check_command         => "check_nrpe_command_timeout!240!check_sslscan_${host_url}",
+      check_interval        => '86400', # Every 12 hours is fine
       service_description   => "SSL Quality ${host_url}",
       host_name             => $::fqdn,
       contact_groups        => $contact_groups,

--- a/manifests/plugins/checksslscan.pp
+++ b/manifests/plugins/checksslscan.pp
@@ -1,0 +1,115 @@
+# == Class: icinga::plugins::checksslscan
+#
+# This defined type provides a checksslscan plugin.
+#
+define icinga::plugins::checksslscan (
+  $host_url              = undef,
+  $host_ip               = undef,
+  $warning_grade         = 'B',
+  $critical_grade        = 'C',
+  $publish_results       = false,
+  $accept_cached_results = true,
+  $max_cache_age         = undef,
+  $debug_mode            = false,
+  $max_check_attempts    = $::icinga::max_check_attempts,
+  $contact_groups        = $::environment,
+  $notification_period   = $::icinga::notification_period,
+  $notifications_enabled = $::icinga::notifications_enabled,
+  $additional_options    = '',
+) {
+
+  require icinga
+
+  validate_string($host_url)
+  validate_string($warning_grade)
+  validate_string($critical_grade)
+  validate_bool($publish_results)
+  validate_bool($accept_cached_results)
+  validate_bool($debug_mode)
+
+  if $publish_results {
+    $_publish_results = '-p '
+  } else {
+    $_publish_results = ''
+  }
+
+  if $accept_cached_results == false {
+    $_accept_cached_results = '-x '
+  } else {
+    $_accept_cached_results = ''
+  }
+
+  if $debug_mode {
+    $_debug_mode = '-d'
+  } else {
+    $_debug_mode = ''
+  }
+
+  if $max_cache_age {
+    $_max_cache_age = "-a ${max_cache_age} "
+  } else {
+    $_max_cache_age = ''
+  }
+
+  if $host_ip {
+    $_ip_address = "-ip ${host_ip} "
+  } else {
+    $_ip_address = ''
+  }
+
+  if $icinga::client {
+
+    # Only include this file once
+    if (!defined(File["${::icinga::plugindir}/check_sslscan.pl"])) {
+      file { "${::icinga::plugindir}/check_sslscan.pl":
+        ensure  => present,
+        mode    => '0755',
+        owner   => 'root',
+        group   => 'root',
+        source  => 'puppet:///modules/icinga/check_sslscan.pl',
+        notify  => Service[$icinga::service_client],
+        require => Class['icinga::config'];
+      }
+    }
+
+    if (!defined(Package['perl-JSON'])) {
+      package { 'perl-JSON':
+        ensure => installed,
+      }
+    }
+
+    if (!defined(Package['perl-Crypt-SSLeay'])) {
+      package { 'perl-Crypt-SSLeay':
+        ensure => installed,
+      }
+    }
+
+    if (!defined(Package['perl-Net-SSLeay'])) {
+      package { 'perl-Net-SSLeay':
+        ensure => installed,
+      }
+    }
+
+    file{"${::icinga::includedir_client}/check_sslscan_${host_url}.cfg":
+      ensure  => 'file',
+      mode    => '0644',
+      owner   => $::icinga::client_user,
+      group   => $::icinga::client_group,
+      content => "command[check_sslscan_${host_url}]=${::icinga::plugindir}/check_sslscan.pl -H ${host_url} -w ${warning_grade} -c ${critical_grade} ${_publish_results}${_accept_cached_results}${_max_cache_age}${_ip_address}${_debug_mode}\n",
+      notify  => Service[$::icinga::service_client],
+    }
+
+    @@nagios_service { "check_sslscan_${::fqdn}_${host_url}":
+      check_command         => "check_nrpe_command_timeout!180!check_sslscan_${host_url}",
+      check_interval        => '3600', # Every hour is fine
+      service_description   => "SSL Quality ${host_url}",
+      host_name             => $::fqdn,
+      contact_groups        => $contact_groups,
+      max_check_attempts    => $max_check_attempts,
+      notification_period   => $notification_period,
+      notifications_enabled => $notifications_enabled,
+      target                => "${::icinga::targetdir}/services/${::fqdn}.cfg",
+    }
+  }
+
+}

--- a/templates/plugins/check_ssl.erb
+++ b/templates/plugins/check_ssl.erb
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# This script checks the content of a file to match with the ssl status.
+#
+VHOST=$1
+
+if [ ! -f "/home/icinga/${VHOST}" ]
+then
+  STATUS=$(cat /home/icinga/${VHOST}_sslresult)
+  if [ "$STATUS" == 'OK - score is A' ]
+  then
+    echo "OK - score is A" && exit 0
+  elif [ "$STATUS" == 'WARNING - score is B' ]
+  then
+    echo "WARNING - score is B" && exit 1
+  else
+    echo "Critical - score is lower then B" && exit 2
+  fi
+else
+  echo "Status file not found in /home/icinga" && exit 3
+fi


### PR DESCRIPTION
This commit adds a check that uses ssllabs API to check the current
grade of a TLS-Enabled website.

Signed-off-by: Patrick Van Brussel patrick@inuits.eu
Signed-off-by: Julien Pivotto roidelapluie@inuits.eu
